### PR TITLE
Fix polytypic use of the call function

### DIFF
--- a/LLVM/Util/Arithmetic.hs
+++ b/LLVM/Util/Arithmetic.hs
@@ -288,7 +288,7 @@ instance (UncurryN a (a1 -> CodeGenFunction r b1), LiftTuple r a1 b, UncurryN a2
     unwrapArgs f = curryN $ \ x -> do x' <- liftTuple x; uncurryN f x'
 
 -- |Lift a function from having @Value@ arguments to having @TValue@ arguments.
-toArithFunction :: (CallArgs f g, UnwrapArgs a a1 b1 b g r) =>
+toArithFunction :: (CallArgs r f g, UnwrapArgs a a1 b1 b g r) =>
                     Function f -> a
 toArithFunction f = unwrapArgs (call f)
 
@@ -296,8 +296,8 @@ toArithFunction f = unwrapArgs (call f)
 
 -- |Define a recursive 'arithFunction', gets passed itself as the first argument.
 recursiveFunction ::
-        (CallArgs a g,
-         UnwrapArgs a11 a1 b1 b g r,
+        (CallArgs r0 a g,
+         UnwrapArgs a11 a1 b1 b g r0,
          FunctionArgs a a2 (CodeGenFunction r1 ()),
          ArithFunction a3 a2,
          IsFunction a) =>


### PR DESCRIPTION
(This is the last pull request, promise :-))

The current definition of CallArgs is incorrect. I found that it did not allow you to compile a client module similar to this:

```
foo :: Function (IO Int32)
foo = undefined

context1 :: CodeGenFunction Word8 (Value Int32)
context1 = call foo

context2 :: CodeGenFunction Word16 (Value Int32)
context2 = call foo
```

The reason is that we have:

```
class CallArgs f g | f -> g, g -> f
instance CallArgs (IO a) (CodeGenFunction r (Value a))
```

The functional dependency claims that f determines g, but in that instance f is (IO a), which does not determine the r type variable. The upshot is that GHC only allows you to instantiate r one way within a single module.

The fix is to make r a parameter of CallArgs so we can declare the correct functional dependencies.
