### PR TITLE
Swap CallArgs order

### DIFF
--- a/LLVM/Core/Instructions.hs
+++ b/LLVM/Core/Instructions.hs
@@ -769,16 +769,16 @@ select (Value cnd) (Value thn) (Value els) =
 type Caller = FFI.BuilderRef -> [FFI.ValueRef] -> IO FFI.ValueRef
 
 -- |Acceptable arguments to 'call'.
-class CallArgs r f g | g -> r f, f r -> g where
+class CallArgs f g r | g -> r f, f r -> g where
     doCall :: Caller -> [FFI.ValueRef] -> f -> g
 
-instance (CallArgs r b b') => CallArgs r (a -> b) (Value a -> b') where
+instance (CallArgs b b' r) => CallArgs (a -> b) (Value a -> b') r where
     doCall mkCall args f (Value arg) = doCall mkCall (arg : args) (f (undefined :: a))
 
 --instance (CallArgs b b') => CallArgs (a -> b) (ConstValue a -> b') where
 --    doCall mkCall args f (ConstValue arg) = doCall mkCall (arg : args) (f (undefined :: a))
 
-instance CallArgs r (IO a) (CodeGenFunction r (Value a)) where
+instance CallArgs (IO a) (CodeGenFunction r (Value a)) r where
     doCall = doCallDef
 
 doCallDef :: Caller -> [FFI.ValueRef] -> b -> CodeGenFunction r (Value a)
@@ -788,11 +788,11 @@ doCallDef mkCall args _ =
 
 -- | Call a function with the given arguments.  The 'call' instruction is variadic, i.e., the number of arguments
 -- it takes depends on the type of /f/.
-call :: (CallArgs r f g) => Function f -> g
+call :: (CallArgs f g r) => Function f -> g
 call (Value f) = doCall (U.makeCall f) [] (undefined :: f)
 
 -- | Call a function with exception handling.
-invoke :: (CallArgs r f g)
+invoke :: (CallArgs f g r)
        => BasicBlock         -- ^Normal return point.
        -> BasicBlock         -- ^Exception return point.
        -> Function f         -- ^Function to call.
@@ -807,7 +807,7 @@ invoke (BasicBlock norm) (BasicBlock expt) (Value f) =
 -- As LLVM itself defines, if the calling conventions of the calling
 -- /instruction/ and the function being /called/ are different, undefined
 -- behavior results.
-callWithConv :: (CallArgs r f g) => FFI.CallingConvention -> Function f -> g
+callWithConv :: (CallArgs f g r) => FFI.CallingConvention -> Function f -> g
 callWithConv cc (Value f) = doCall (U.makeCallWithCc cc f) [] (undefined :: f)
 
 -- | Call a function with exception handling.
@@ -815,7 +815,7 @@ callWithConv cc (Value f) = doCall (U.makeCallWithCc cc f) [] (undefined :: f)
 -- As LLVM itself defines, if the calling conventions of the calling
 -- /instruction/ and the function being /called/ are different, undefined
 -- behavior results.
-invokeWithConv :: (CallArgs r f g)
+invokeWithConv :: (CallArgs f g r)
                => FFI.CallingConvention -- ^Calling convention
                -> BasicBlock         -- ^Normal return point.
                -> BasicBlock         -- ^Exception return point.

--- a/LLVM/Util/Arithmetic.hs
+++ b/LLVM/Util/Arithmetic.hs
@@ -288,7 +288,7 @@ instance (UncurryN a (a1 -> CodeGenFunction r b1), LiftTuple r a1 b, UncurryN a2
     unwrapArgs f = curryN $ \ x -> do x' <- liftTuple x; uncurryN f x'
 
 -- |Lift a function from having @Value@ arguments to having @TValue@ arguments.
-toArithFunction :: (CallArgs r f g, UnwrapArgs a a1 b1 b g r) =>
+toArithFunction :: (CallArgs f g r, UnwrapArgs a a1 b1 b g r) =>
                     Function f -> a
 toArithFunction f = unwrapArgs (call f)
 
@@ -296,7 +296,7 @@ toArithFunction f = unwrapArgs (call f)
 
 -- |Define a recursive 'arithFunction', gets passed itself as the first argument.
 recursiveFunction ::
-        (CallArgs r0 a g,
+        (CallArgs a g r0,
          UnwrapArgs a11 a1 b1 b g r0,
          FunctionArgs a a2 (CodeGenFunction r1 ()),
          ArithFunction a3 a2,


### PR DESCRIPTION
Further to our discussion on the haskell-llvm list, Henning Thielemann wanted CallArgs to have the r parameter as the last one rather than the first one.

Thanks,
Max
