### PR TITLE
Adding export of TypeHandleRef

### DIFF
--- a/LLVM/FFI/Core.hsc
+++ b/LLVM/FFI/Core.hsc
@@ -85,6 +85,7 @@ module LLVM.FFI.Core
     , isPackedStruct
 
     -- * Type handles
+    , TypeHandleRef
     , createTypeHandle
     , refineType
     , resolveTypeHandle


### PR DESCRIPTION
The LLVM.FFI.Core module exports functions to create and work with type handles, but doesn't export the TypeHandleRef explicitly. This just adds the export of the type to the module.
