### PR TITLE
Add support for defining string literals within CodeGenFunction

### DIFF
--- a/LLVM/Core/CodeGen.hs
+++ b/LLVM/Core/CodeGen.hs
@@ -445,25 +445,35 @@ createString s = string (length s) (U.constString s)
 createStringNul :: String -> TGlobal (Array n Word8)
 createStringNul s = string (length s + 1) (U.constStringNul s)
 
-withString ::
-   String ->
-   (forall n. (Nat n) => Global (Array n Word8) -> CodeGenModule a) ->
-   CodeGenModule a
-withString s act =
-   let n = length s
-   in  reifyIntegral n (\tn ->
-          do arr <- string n (U.constString s)
-             act (fixArraySize tn arr))
+class WithString a where
+  withString    :: String -> (forall n . Nat n => Global (Array n Word8) -> a) -> a
+  withStringNul :: String -> (forall n . Nat n => Global (Array n Word8) -> a) -> a
 
-withStringNul ::
-   String ->
-   (forall n. (Nat n) => Global (Array n Word8) -> CodeGenModule a) ->
-   CodeGenModule a
-withStringNul s act =
-   let n = length s + 1
-   in  reifyIntegral n (\tn ->
-          do arr <- string n (U.constStringNul s)
-             act (fixArraySize tn arr))
+instance WithString (CodeGenModule a) where
+  withString s act =
+     let n = length s
+     in  reifyIntegral n (\tn ->
+            do arr <- string n (U.constString s)
+               act (fixArraySize tn arr))
+
+  withStringNul s act =
+     let n = length s + 1
+     in  reifyIntegral n (\tn ->
+            do arr <- string n (U.constStringNul s)
+               act (fixArraySize tn arr))
+
+instance WithString (CodeGenFunction r b) where
+  withString s act =
+     let n = length s
+     in  reifyIntegral n (\tn ->
+            do arr <- liftCodeGenModule $ string n (U.constString s)
+               act (fixArraySize tn arr))
+
+  withStringNul s act =
+     let n = length s + 1
+     in  reifyIntegral n (\tn ->
+            do arr <- liftCodeGenModule $ string n (U.constStringNul s)
+               act (fixArraySize tn arr))
 
 fixArraySize :: n -> Global (Array n a) -> Global (Array n a)
 fixArraySize _ = id


### PR DESCRIPTION
I find that it is convenient to define a new string literal within a CodeGenFunction. This patch generalizes withString/withStringNul to both CodeGen\* types.
