### PR TITLE
Fix a bug with String's length

### DIFF
--- a/LLVM/Core/CodeGen.hs
+++ b/LLVM/Core/CodeGen.hs
@@ -439,20 +439,24 @@ type TGlobal a = CodeGenModule (Global a)
 -- Special string creators
 {-# DEPRECATED createString "use withString instead" #-}
 createString :: String -> TGlobal (Array n Word8)
-createString s = string (length s) (U.constString s)
+createString s =
+    let (cstr, n) = U.constString s
+    in string n cstr
 
 {-# DEPRECATED createStringNul "use withStringNul instead" #-}
 createStringNul :: String -> TGlobal (Array n Word8)
-createStringNul s = string (length s + 1) (U.constStringNul s)
+createStringNul s =
+    let (cstr, n) = U.constStringNul s
+    in string n cstr
 
 withString ::
    String ->
    (forall n. (Nat n) => Global (Array n Word8) -> CodeGenModule a) ->
    CodeGenModule a
 withString s act =
-   let n = length s
+   let (cstr, n) = U.constString s
    in  reifyIntegral n (\tn ->
-          do arr <- string n (U.constString s)
+          do arr <- string n cstr
              act (fixArraySize tn arr))
 
 withStringNul ::
@@ -460,9 +464,9 @@ withStringNul ::
    (forall n. (Nat n) => Global (Array n Word8) -> CodeGenModule a) ->
    CodeGenModule a
 withStringNul s act =
-   let n = length s + 1
+   let (cstr, n) = U.constStringNul s
    in  reifyIntegral n (\tn ->
-          do arr <- string n (U.constStringNul s)
+          do arr <- string n cstr
              act (fixArraySize tn arr))
 
 fixArraySize :: n -> Global (Array n a) -> Global (Array n a)

--- a/LLVM/Core/Util.hs
+++ b/LLVM/Core/Util.hs
@@ -271,16 +271,18 @@ addGlobal modul linkage name typ =
         return v
 
 -- unsafePerformIO is safe because it's only used for the withCStringLen conversion
-constStringInternal :: Bool -> String -> Value
+constStringInternal :: Bool -> String -> (Value, Int)
 constStringInternal nulTerm s = unsafePerformIO $
     withCStringLen s $ \(sPtr, sLen) ->
-      return $ FFI.constString sPtr (fromIntegral sLen) (fromBool (not nulTerm))
+      return (FFI.constString sPtr (fromIntegral sLen) (fromBool (not nulTerm)), sLen)
 
-constString :: String -> Value
+constString :: String -> (Value, Int)
 constString = constStringInternal False
 
-constStringNul :: String -> Value
-constStringNul = constStringInternal True
+constStringNul :: String -> (Value, Int)
+constStringNul str =
+    let (cstr, n) = constStringInternal True str
+    in (cstr, n+1)
 
 --------------------------------------
 


### PR DESCRIPTION
When creating a string (using either `createString*' or `withString*' functions)
we must not use `length' function to compute the length of a string
in bytes (as this will return the length of a string in chars).
Instead we should use the same length used by `withCStringLen' function.

This bug appears when using `createString*' or `withString*' functions with
a string containing characters bigger than 7-bits (in my case when using
greek letters).

For example the above code will generate one llvm module (named greet.bc)
which fails to compile when using llc with message:
`Global variable initializer type does not match global variable type!'

``` haskell
module Main (main) where

import Data.Word
import LLVM.Core

bldGreet :: CodeGenModule (Function (IO ()))
bldGreet = withStringNul "My name is Ηλίας" (\greetz -> do
    puts <- newNamedFunction ExternalLinkage "puts" :: TFunction (Ptr Word8 -> IO Word32)
    func <- createFunction ExternalLinkage $ do
      tmp <- getElementPtr0 greetz (0::Word32, ())
      _ <- call puts tmp -- Throw away return value.
      ret ()
    return func)

main :: IO ()
main = do
    m <- newModule
    defineModule m bldGreet
    writeBitcodeToFile "greet.bc" m
```
