### PR TITLE
cabal install llvm-base fails on arch

### DIFF
--- a/base/cbits/extra.cpp
+++ b/base/cbits/extra.cpp
@@ -387,7 +387,7 @@ LLVMModuleRef LLVMGetModuleFromAssembly(const char *asmtext, unsigned txtlen,
                                               llvm::getGlobalContext()))) {
         std::string s;
         llvm::raw_string_ostream buf(s);
-        error.Print("llvm-py", buf);
+        error.print("llvm-py", buf);
         *out = strdup(buf.str().c_str());
         return NULL;
     }


### PR DESCRIPTION
cabal install llvm-base fails with the error on arch linux

bits/extra.cpp:390:15:  error: ‘class llvm::SMDiagnostic’ has no member named ‘Print’

on changing the error.Print on line 390 to error.print build succeeds
