### PR TITLE
Fix issue associated with SVN LLVM.

### DIFF
--- a/base/configure.ac
+++ b/base/configure.ac
@@ -125,7 +125,7 @@ if test "$ac_cv_lib_LLVMCore_LLVMModuleCreateWithName" = "no"; then
     [AC_MSG_ERROR(could not find LLVM C bindings)])
 fi
 
-llvm_num_version="`echo $llvm_version | tr . 0`"
+llvm_num_version="`echo $llvm_version | tr . 0 | sed 's/^\([[0-9]][[0-9]]*\).*$/\1/g'`"
 AC_DEFINE_UNQUOTED([HS_LLVM_VERSION], [$llvm_num_version],
   [Define to the version of LLVM, e.g. 209 for 2.9.])
 


### PR DESCRIPTION
When compiling the Haskell binding against a SVN version of LLVM, the output of `llvm-config --version` is (for example) `3.0svn`.

This causes the `HS_LLVM_VERSION` variable to become `300svn` and breaks all preprocessor `#if` checks on said variable.

Commit c6d1c5c fixes the issue by stripping the "svn" (or any other suffix) from the version string. 
