### PR TITLE
llvm-base: Don't declare DbgInfoPrinter pass with LLVM 3.3

### DIFF
--- a/base/include/extra.h
+++ b/base/include/extra.h
@@ -207,7 +207,9 @@ define_pass( AlwaysInliner )
 declare_pass( BlockPlacement )
 declare_pass( BreakCriticalEdges )
 declare_pass( CodeGenPrepare )
+#if HS_LLVM_VERSION < 303
 declare_pass( DbgInfoPrinter )
+#endif
 declare_pass( DeadCodeElimination )
 declare_pass( DeadInstElimination )
 declare_pass( DemoteRegisterToMemory )


### PR DESCRIPTION
Keeps consistency between extra.cpp & extra.h
This should have been included in:
d01855daab68727da55db94d35fa8b620dd485d0
