### PR TITLE
llvm-base: Move all pass declarations to extra.h

### DIFF
--- a/base/cbits/extra.cpp
+++ b/base/cbits/extra.cpp
@@ -601,75 +601,29 @@ bool LLVMAddEmitObjectPass (LLVMModuleRef modRef, const char* filename)
 }
 #endif
 
-/* Passes. A few passes (listed below) are used directly from LLVM-C,
- * rest are defined here.
- */
-
-#define define_pass(P)                                   \
-void LLVMAdd ## P ## Pass (LLVMPassManagerRef passmgr) { \
-    using namespace llvm;                                \
-    llvm::PassManagerBase *pmp = llvm::unwrap(passmgr);  \
-    assert(pmp);                                         \
-    pmp->add( create ## P ## Pass ());                   \
-}
-
-define_pass( AAEval )
-define_pass( AliasAnalysisCounter )
-
-#if HS_LLVM_VERSION < 302
-define_pass( AlwaysInliner )
-#endif 
-// Name conflicts with those in LLVM proper, have a safer prefix?
-// define_pass( BasicAliasAnalysis )
-define_pass( BlockPlacement )
-define_pass( BreakCriticalEdges )
-define_pass( CodeGenPrepare )
-#if HS_LLVM_VERSION < 303
-define_pass( DbgInfoPrinter )
-#endif
-define_pass( DeadCodeElimination )
-define_pass( DeadInstElimination )
-define_pass( DemoteRegisterToMemory )
-define_pass( DomOnlyPrinter )
-define_pass( DomOnlyViewer )
-define_pass( DomPrinter )
-define_pass( DomViewer )
-define_pass( DependenceAnalysis )
-define_pass( EdgeProfiler )
-define_pass( GlobalsModRef )
-define_pass( InstCount )
-define_pass( InstructionNamer )
-define_pass( LazyValueInfo )
-define_pass( LCSSA )
-define_pass( LoopExtractor )
-define_pass( LoopSimplify )
-define_pass( LoopStrengthReduce )
-define_pass( LowerInvoke )
-define_pass( LowerSwitch )
-define_pass( MergeFunctions )
-define_pass( NoAA )
-define_pass( NoProfileInfo )
-define_pass( OptimalEdgeProfiler )
-define_pass( PartialInlining )
-define_pass( PostDomOnlyPrinter )
-define_pass( PostDomOnlyViewer )
-define_pass( PostDomPrinter )
-define_pass( PostDomViewer )
-define_pass( ProfileEstimator )
-define_pass( ProfileLoader )
-define_pass( ProfileVerifier )
-define_pass( ScalarEvolutionAliasAnalysis )
-define_pass( SingleLoopExtractor )
-define_pass( StripNonDebugSymbols )
-define_pass( UnifyFunctionExitNodes )
-define_pass( Internalize )
+/* Passes */
 
 /* we support only internalize(true) */
 llvm::ModulePass *createInternalize2Pass() {
   return llvm::createInternalizePass(); 
 }
 
-define_pass( Internalize2 )
+/* All passes are listed in passes-inl.h
+ * The list is shared between extra.cpp and extra.h.
+ *
+ * In this file the declare_or_define_pass macro is used to expand
+ * the passes into function definitions.
+ */
+#define declare_or_define_pass(P)                        \
+void LLVMAdd ## P ## Pass (LLVMPassManagerRef passmgr) { \
+    using namespace llvm;                                \
+    llvm::PassManagerBase *pmp = llvm::unwrap(passmgr);  \
+    assert(pmp);                                         \
+    pmp->add( create ## P ## Pass ());                   \
+}
+#include "passes-inl.h"
+#undef declare_or_define_pass
+
 
 #if HS_LLVM_VERSION < 302
 LLVMBool LLVMPrintModuleToFile(LLVMModuleRef M, const char *Filename,

--- a/base/include/extra.h
+++ b/base/include/extra.h
@@ -191,64 +191,16 @@ int LLVMInlineFunction(LLVMValueRef call);
 bool LLVMAddEmitObjectPass (LLVMModuleRef modRef, const char* filename);
 #endif
 
-/* Passes. Some passes are used directly from LLVM-C, rest are declared
- * here. */
-
-#define declare_pass(P) \
+/* All passes are listed in passes-inl.h
+ * The list is shared between extra.cpp and extra.h.
+ *
+ * In this file the declare_or_define_pass macro is used to expand
+ * the passes into function declarations.
+ */
+#define declare_or_define_pass(P) \
     void LLVMAdd ## P ## Pass (LLVMPassManagerRef PM);
-
-declare_pass( AAEval )
-declare_pass( AliasAnalysisCounter )
-#if HS_LLVM_VERSION < 302
-define_pass( AlwaysInliner )
-#endif 
-// Name conflicts with those in LLVM proper, have a safer prefix?
-// declare_pass( BasicAliasAnalysis )
-declare_pass( BlockPlacement )
-declare_pass( BreakCriticalEdges )
-declare_pass( CodeGenPrepare )
-#if HS_LLVM_VERSION < 303
-declare_pass( DbgInfoPrinter )
-#endif
-declare_pass( DeadCodeElimination )
-declare_pass( DeadInstElimination )
-declare_pass( DemoteRegisterToMemory )
-declare_pass( DomOnlyPrinter )
-declare_pass( DomOnlyViewer )
-declare_pass( DomPrinter )
-declare_pass( DomViewer )
-declare_pass( EdgeProfiler )
-declare_pass( GlobalsModRef )
-declare_pass( InstCount )
-declare_pass( InstructionNamer )
-declare_pass( LazyValueInfo )
-declare_pass( LCSSA )
-declare_pass( LoopDependenceAnalysis )
-declare_pass( LoopExtractor )
-declare_pass( LoopSimplify )
-declare_pass( LoopStrengthReduce )
-declare_pass( LowerInvoke )
-declare_pass( LowerSwitch )
-declare_pass( MergeFunctions )
-declare_pass( NoAA )
-declare_pass( NoProfileInfo )
-declare_pass( OptimalEdgeProfiler )
-declare_pass( PartialInlining )
-declare_pass( PostDomOnlyPrinter )
-declare_pass( PostDomOnlyViewer )
-declare_pass( PostDomPrinter )
-declare_pass( PostDomViewer )
-declare_pass( ProfileEstimator )
-declare_pass( ProfileLoader )
-declare_pass( ProfileVerifier )
-declare_pass( ScalarEvolutionAliasAnalysis )
-declare_pass( SingleLoopExtractor )
-declare_pass( StripNonDebugSymbols )
-declare_pass( StructRetPromotion )
-declare_pass( TailDuplication )
-declare_pass( UnifyFunctionExitNodes )
-
-declare_pass( Internalize2 )
+#include "passes-inl.h"
+#undef declare_or_define_pass
 
 #if HS_LLVM_VERSION < 302
 LLVMBool LLVMPrintModuleToFile(LLVMModuleRef M, const char *Filename, char **ErrorMessage);

--- a/base/include/passes-inl.h
+++ b/base/include/passes-inl.h
@@ -1,0 +1,66 @@
+#ifdef declare_or_define_pass
+
+/* LLVM-C passes */
+
+declare_or_define_pass( AAEval )
+declare_or_define_pass( AliasAnalysisCounter )
+#if HS_LLVM_VERSION < 302
+declare_or_define_pass( AlwaysInliner )
+#endif
+// Name conflicts with those in LLVM proper, have a safer prefix?
+// declare_or_define_pass( BasicAliasAnalysis )
+declare_or_define_pass( BlockPlacement )
+declare_or_define_pass( BreakCriticalEdges )
+declare_or_define_pass( CodeGenPrepare )
+#if HS_LLVM_VERSION < 303
+declare_or_define_pass( DbgInfoPrinter )
+#endif
+declare_or_define_pass( DeadCodeElimination )
+declare_or_define_pass( DeadInstElimination )
+declare_or_define_pass( DemoteRegisterToMemory )
+declare_or_define_pass( DomOnlyPrinter )
+declare_or_define_pass( DomOnlyViewer )
+declare_or_define_pass( DomPrinter )
+declare_or_define_pass( DomViewer )
+declare_or_define_pass( EdgeProfiler )
+declare_or_define_pass( GlobalsModRef )
+declare_or_define_pass( InstCount )
+declare_or_define_pass( InstructionNamer )
+declare_or_define_pass( LazyValueInfo )
+declare_or_define_pass( LCSSA )
+#if HS_LLVM_VERSION < 302
+declare_or_define_pass( LoopDependenceAnalysis )
+#endif
+declare_or_define_pass( LoopExtractor )
+declare_or_define_pass( LoopSimplify )
+declare_or_define_pass( LoopStrengthReduce )
+declare_or_define_pass( LowerInvoke )
+declare_or_define_pass( LowerSwitch )
+declare_or_define_pass( MergeFunctions )
+declare_or_define_pass( NoAA )
+declare_or_define_pass( NoProfileInfo )
+declare_or_define_pass( OptimalEdgeProfiler )
+declare_or_define_pass( PartialInlining )
+declare_or_define_pass( PostDomOnlyPrinter )
+declare_or_define_pass( PostDomOnlyViewer )
+declare_or_define_pass( PostDomPrinter )
+declare_or_define_pass( PostDomViewer )
+declare_or_define_pass( ProfileEstimator )
+declare_or_define_pass( ProfileLoader )
+declare_or_define_pass( ProfileVerifier )
+declare_or_define_pass( ScalarEvolutionAliasAnalysis )
+declare_or_define_pass( SingleLoopExtractor )
+declare_or_define_pass( StripNonDebugSymbols )
+#if HS_LLVM_VERSION < 300
+declare_or_define_pass( StructRetPromotion )
+declare_or_define_pass( TailDuplication )
+#endif
+declare_or_define_pass( UnifyFunctionExitNodes )
+
+
+
+/* Passes declared in extra.cpp goes here */
+
+declare_or_define_pass( Internalize2 )
+
+#endif


### PR DESCRIPTION
Move all pass declarations and definitions to extra.h.
This way consistency is maintained between extra.h and extra.cpp

When extra.h is included from extra.cpp LLVM_PY_EXTRA_CPP_DEFINE_PASSES is
defined. This makes the declare_or_define_pass macro expand to a function definition
instead of a declaration.

When extra.h is included normally, the declare_or_define_pass macro will expand to
a function declaration.
