### PR TITLE
Fix the List.hs example

### DIFF
--- a/examples/List.hs
+++ b/examples/List.hs
@@ -4,7 +4,7 @@ module List(main) where
 
 import LLVM.Util.Loop (Phi, phis, addPhis, )
 import LLVM.ExecutionEngine (simpleFunction, )
-import LLVM.Core
+import LLVM.Core hiding (sizeOf)
 import qualified System.IO as IO
 
 import Data.Word (Word32, )


### PR DESCRIPTION
LLVM.Core includes a sizeOf function which caused GHC to fail with an
ambiguous occurrence error. I've hidden the LLVM.Core sizeOf function.
